### PR TITLE
Fix imports, likely caused by a case-insensitive file system

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3,7 +3,7 @@ package impalathing
 import (
 	"fmt"
 	"git.apache.org/thrift.git/lib/go/thrift"
-	impala "github.com/koblas/impalathing/services/ImpalaService"
+	impala "github.com/koblas/impalathing/services/impalaservice"
 	"github.com/koblas/impalathing/services/beeswax"
 )
 

--- a/rowset.go
+++ b/rowset.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	impala "github.com/koblas/impalathing/services/ImpalaService"
+	impala "github.com/koblas/impalathing/services/impalaservice"
 	"github.com/koblas/impalathing/services/beeswax"
 )
 


### PR DESCRIPTION
As is, on a Linux system, you'll get an error message like:

```
connection.go:6:2: cannot find package "github.com/koblas/impalathing/services/ImpalaService" in any of:
        /home/noah/go-tip/src/github.com/koblas/impalathing/services/ImpalaService (from $GOROOT)
```

because the imports in `connection.go` and `rowset.go` refer to github.com/koblas/impalathing/services/ImpalaService; in the actual repository, that directory is lower-case. On a case-insensitive file system (like OS X by default), this won't matter, but it does on anything that is case sensitive.
