### PR TITLE
Add FetchAll() to get & convert all rows of response

### DIFF
--- a/rowset.go
+++ b/rowset.go
@@ -25,6 +25,8 @@ type rowSet struct {
 	hasMore bool
 	ready   bool
 
+	metadata *beeswax.ResultsMetadata
+
 	nextRow []string
 }
 
@@ -38,6 +40,7 @@ type RowSet interface {
 	Scan(dest ...interface{}) error
 	Poll() (*Status, error)
 	Wait() (*Status, error)
+	FetchAll() []map[string]interface{}
 }
 
 // Represents job status, including success state and time the
@@ -48,7 +51,8 @@ type Status struct {
 }
 
 func newRowSet(client *impala.ImpalaServiceClient, handle *beeswax.QueryHandle, options Options) RowSet {
-	return &rowSet{client, handle, options, nil, 0, nil, true, false, nil}
+  return &rowSet{client: client, handle: handle, options: options, columnNames: nil, offset: 0, rowSet: nil, 
+  hasMore: true, ready: false, metadata: nil, nextRow: nil}
 }
 
 //
@@ -133,6 +137,12 @@ func (r *rowSet) Next() bool {
 			return false
 		}
 
+		if r.metadata == nil {
+		  r.metadata, err = r.client.GetResultsMetadata(r.handle)
+		  if err != nil {
+				log.Printf("GetResultsMetadata failed: %v\n", err)
+			  }
+		}
 		if len(r.columnNames) == 0 {
 			r.columnNames = resp.Columns
 		}
@@ -207,6 +217,49 @@ func (r *rowSet) Scan(dest ...interface{}) error {
 	return nil
 }
 
+
+//Convert from a hive column type to a Go type
+func (r *rowSet) convertRawValue(raw string, hiveType string) (interface{}, error) {
+		switch hiveType {
+		case "string":
+			return raw, nil
+		case "int", "tinyint", "smallint":
+			i, err := strconv.ParseInt(raw, 10, 0)
+			return int32(i), err
+		case "bigint":
+			i, err := strconv.ParseInt(raw, 10, 0)
+			return int64(i), err
+		case "float", "double", "decimal":
+		  i, err := strconv.ParseFloat(raw, 64)
+		  return i, err
+		case "timestamp":
+		  i, err := time.Parse("2006-01-02 15:04:05", raw)
+		  return i, err
+		case "boolean":
+		  return raw == "true", nil
+		default:
+			return nil, errors.New(fmt.Sprintf("Invalid hive type %v", hiveType))
+		}
+}
+
+//Fetch all rows and convert to a []map[string]interface{} with 
+//appropriate type conversion already carried out
+func (r *rowSet) FetchAll() ([]map[string]interface{} ) {
+	response := make([]map[string]interface{},0)
+	for r.Next() {
+	  row := make(map[string]interface{})
+	  for i, val := range r.nextRow {
+		conv, err := r.convertRawValue(val, r.metadata.Schema.FieldSchemas[i].TypeA1)
+		if err != nil {
+		  fmt.Printf("%v\n", err)
+		}
+		row[r.metadata.Schema.FieldSchemas[i].Name] = conv 
+	  }
+	  response = append(response, row)
+	}
+	return response
+}
+
 // Returns the names of the columns for the given operation,
 // blocking if necessary until the information is available.
 func (r *rowSet) Columns() []string {
@@ -218,3 +271,4 @@ func (r *rowSet) Columns() []string {
 
 	return r.columnNames
 }
+


### PR DESCRIPTION
Great library! I'm not sure if you're interested in entertaining API changes, but if so, perhaps this will be of interest to you: this pull request adds a `FetchAll()` method that grabs all of the available rows, determines the appropriate Go type corresponding to the original Impala/Hive, and grabs the column names, and returns a `[]map[string]interface{}.

Usage looks like:

``` go
conn, _ := impalathing.Connect("bigdata-02", 21000, impalathing.DefaultOptions)
query, _ := conn.Query("SELECT * FROM mytable LIMIT 10")
rows := query.FetchAll()
for i := range rows {
   fmt.Printf("string: %v, float: %v\n", rows[i]["stringCol"].(string), rows[i]["floatCol"].(float64))
}
```
