### PR TITLE
Create connection with plain SaslTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ func main() {
     host := "impala-host"
     port := 21000
 
-    useKerberos := true
-    con, err := impalathing.Connect(host, port, impalathing.DefaultOptions, useKerberos)
-
+    con, err := impalathing.Connect(host, port)
+    // if you use kerberos
+    con, err := impalathing.Connect(host, port, impalathing.WithGSSAPISaslTransport()) 
     if err != nil {
         log.Fatal("Error connecting", err)
         return

--- a/sasl_transport.go
+++ b/sasl_transport.go
@@ -38,8 +38,9 @@ type TSaslTransport struct {
 }
 
 // NewTSaslTransport return a TSaslTransport
-func NewTSaslTransport(trans thrift.TTransport, host string, mechanismName string, configuration map[string]string) (*TSaslTransport, error) {
+func NewTSaslTransport(trans thrift.TTransport, host string, configuration map[string]string) (*TSaslTransport, error) {
 	var mechanism gosasl.Mechanism
+	mechanismName, _ := configuration["mechanismName"]
 	if mechanismName == "PLAIN" {
 		mechanism = gosasl.NewPlainMechanism(configuration["username"], configuration["password"])
 	} else if mechanismName == "GSSAPI" {


### PR DESCRIPTION
Problem: Tried to create plain SASL transport and was unable to do so

TSaslTransport already supports it [here](https://github.com/koblas/impalathing/blob/84e5f9c518e1d1c8f1d2de51ed27b6edb7e0355e/sasl_transport.go#L43), so I only had to change the `Connect()` function. It kinda breaks the backward-compatibility in a little way

I would be glad to read your comments if you have any ideas how to make that change look better